### PR TITLE
increase default memory allocation

### DIFF
--- a/make_prg_nexflow.nf
+++ b/make_prg_nexflow.nf
@@ -23,7 +23,7 @@ split_tsv = Channel.from(input_tsv).splitCsv(header: true, sep:'\t')
 process make_prg {
     maxForks params.max_forks_make_prg
     errorStrategy {task.attempt < 10 ? 'retry' : 'ignore'}
-    memory {params.testing ? '0.5 GB' : 0.5.GB * task.attempt * task.attempt}
+    memory {params.testing ? '0.1 GB' : 0.1.GB * task.attempt * task.attempt * task.attempt}
     maxRetries 10
 
     input:

--- a/make_prg_nexflow.nf
+++ b/make_prg_nexflow.nf
@@ -23,7 +23,7 @@ split_tsv = Channel.from(input_tsv).splitCsv(header: true, sep:'\t')
 process make_prg {
     maxForks params.max_forks_make_prg
     errorStrategy {task.attempt < 10 ? 'retry' : 'ignore'}
-    memory {params.testing ? '0.1 GB' : 0.1.GB * task.attempt * task.attempt}
+    memory {params.testing ? '0.5 GB' : 0.5.GB * task.attempt * task.attempt}
     maxRetries 10
 
     input:


### PR DESCRIPTION
I find that a lot of my PRG jobs max out the memory limit, even on the 10th attempt. Starting with 0.5GB seems to work for all of my 1800 jobs I just ran so I guess thats a good default?