### PR TITLE
update default max nesting level

### DIFF
--- a/make_prg_from_msa.py
+++ b/make_prg_from_msa.py
@@ -594,8 +594,8 @@ def main():
     parser.add_argument("-f", "--alignment_format", dest='alignment_format', action='store', default="fasta",
                         help='alignment_Format of MSA, must be a biopython AlignIO input alignment_format. See '
                              'http://biopython.org/wiki/AlignIO. Default: fasta')
-    parser.add_argument("--max_nesting", dest='max_nesting', action='store', type=int, default=10,
-                        help='Maximum number of levels to use for nesting. Default: 10')
+    parser.add_argument("--max_nesting", dest='max_nesting', action='store', type=int, default=5,
+                        help='Maximum number of levels to use for nesting. Default: 5')
     parser.add_argument("--min_match_length", dest='min_match_length', action='store', type=int, default=7,
                         help='Minimum number of consecutive characters which must be identical for a match. '
                              'Default: 7')

--- a/make_prg_nexflow.nf
+++ b/make_prg_nexflow.nf
@@ -1,7 +1,7 @@
 params.tsv_in = ""
 params.testing = false
 params.pipeline_root = ""
-params.max_nesting = 10
+params.max_nesting = 5
 params.min_match_length = 7
 params.alignment_format = "fasta"
 params.final_outdir = "."


### PR DESCRIPTION
Make the default nesting level 5.  

The current default of 10 is a bit too high. See [this notebook](https://nbviewer.jupyter.org/github/mbhall88/pandora_simulations/blob/master/scripts/results.ipynb) for supporting information.