### PR TITLE
Add fasta header to PRG file

### DIFF
--- a/make_prg/subcommands/prg_from_msa.py
+++ b/make_prg/subcommands/prg_from_msa.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from pathlib import Path
 
 from make_prg import make_prg_from_msa, utils
 
@@ -65,7 +66,8 @@ def run(options):
     logging.info("Write GFA file to %s.gfa", prefix)
     utils.write_gfa("%s.gfa" % prefix, aseq.prg)
 
-    with open("summary.tsv", "a") as s:
+    summary_file = Path(prefix).parent / "summary.tsv"
+    with summary_file.open("a") as s:
         s.write(
             "%s\t%d\t%d\t%f\n"
             % (

--- a/make_prg/utils.py
+++ b/make_prg/utils.py
@@ -149,7 +149,7 @@ def write_prg(output_prefix: str, prg_string: str):
     prg_filename = Path(output_prefix + ".prg")
     with prg_filename.open("w") as prg:
         regex = re.compile(
-            r"^(?P<sample>\w+)\.max_nest(?P<max_nest>\d+)\.min_match(?P<min_match>\d+)"
+            r"^(?P<sample>.+)\.max_nest(?P<max_nest>\d+)\.min_match(?P<min_match>\d+)"
         )
         match = regex.search(prg_filename.stem)
         try:

--- a/make_prg/utils.py
+++ b/make_prg/utils.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from pathlib import Path
 from typing import Generator, Sequence
 
 from make_prg.prg_encoder import PrgEncoder
@@ -140,19 +141,22 @@ def write_gfa(outfile, prg_string):
 # *****************/
 
 
-def write_prg(outf_prefix, prg_string):
+def write_prg(output_prefix: str, prg_string: str):
     """
     Writes the prg to outfile.
     Writes it as a human readable string, and also as an integer vector
     """
-    out_name = f"{outf_prefix}.prg"
-    with open(out_name, "w") as f:
-        f.write(prg_string)
+    prg_filename = Path(output_prefix + ".prg")
+    with prg_filename.open("w") as prg:
+        header = prg_filename.stem
+        print(
+            ">{header}\n{prg_string}".format(header=header, prg_string=prg_string),
+            file=prg,
+        )
 
-    out_name = f"{outf_prefix}.bin"
+    binary_encoding_filename = Path(output_prefix + ".bin")
     prg_encoder = PrgEncoder()
     prg_encoding = prg_encoder.encode(prg_string)
-    # print(int_enc.vector.elements)
 
-    with open(out_name, "wb") as write_to:
+    with binary_encoding_filename.open("wb") as write_to:
         prg_encoder.write_encoding_to(prg_encoding, write_to)

--- a/make_prg/utils.py
+++ b/make_prg/utils.py
@@ -163,7 +163,7 @@ def write_prg(output_prefix: str, prg_string: str):
 
         max_nest = int(match.group("max_nest"))
         min_match = int(match.group("min_match"))
-        header = ">{sample} max_nest={max_nest} min_match={min_match}".format(
+        header = "{sample} max_nest={max_nest} min_match={min_match}".format(
             sample=sample, max_nest=max_nest, min_match=min_match
         )
         print(

--- a/make_prg/utils.py
+++ b/make_prg/utils.py
@@ -148,7 +148,24 @@ def write_prg(output_prefix: str, prg_string: str):
     """
     prg_filename = Path(output_prefix + ".prg")
     with prg_filename.open("w") as prg:
-        header = prg_filename.stem
+        regex = re.compile(
+            r"^(?P<sample>\w+)\.max_nest(?P<max_nest>\d+)\.min_match(?P<min_match>\d+)"
+        )
+        match = regex.search(prg_filename.stem)
+        try:
+            sample = match.group("sample")
+        except IndexError:
+            logging.warning(
+                "A sample name couldn't be parsed from the prefix. "
+                "Using 'sample' as sample name."
+            )
+            sample = "sample"
+
+        max_nest = int(match.group("max_nest"))
+        min_match = int(match.group("min_match"))
+        header = ">{sample} max_nest={max_nest} min_match={min_match}".format(
+            sample=sample, max_nest=max_nest, min_match=min_match
+        )
         print(
             ">{header}\n{prg_string}".format(header=header, prg_string=prg_string),
             file=prg,


### PR DESCRIPTION
1. Write fasta-style header to `.prg` file [closes #9 ]. The way the header is specified is as the stem of the output prefix. So if the output prefix is `path/to/output` then the fasta header will be `>output.max_nest5.min_match7`. Let me know if there are any problems with this convention.
2. Write the `summary.tsv` file to the same directory as all of the other output files (i.e the directory of `--prefix`)