### PR TITLE
Refactoring and more unit tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: stable
+    hooks:
+      - id: black
+        language_version: python3.6

--- a/make_prg/__init__.py
+++ b/make_prg/__init__.py
@@ -5,6 +5,6 @@ try:
 except:
     __version__ = "local"
 
-__all__ = ["make_prg_from_msa", "subcommands", "utils"]
+__all__ = ["make_prg_from_msa", "subcommands", "io_utils", "seq_utils"]
 
 from make_prg import *

--- a/make_prg/exceptions.py
+++ b/make_prg/exceptions.py
@@ -1,0 +1,2 @@
+class ClusteringError(Exception):
+    pass

--- a/make_prg/io_utils.py
+++ b/make_prg/io_utils.py
@@ -7,6 +7,7 @@ from Bio import AlignIO
 
 from make_prg.prg_encoder import PrgEncoder
 
+
 def load_alignment_file(msa_file: str, alignment_format: str):
     logging.info("Read from MSA file %s", msa_file)
     if ".gz" in msa_file:

--- a/make_prg/io_utils.py
+++ b/make_prg/io_utils.py
@@ -8,7 +8,9 @@ from Bio import AlignIO
 from make_prg.prg_encoder import PrgEncoder
 
 
-def load_alignment_file(msa_file: str, alignment_format: str):
+def load_alignment_file(
+    msa_file: str, alignment_format: str
+) -> AlignIO.MultipleSeqAlignment:
     logging.info("Read from MSA file %s", msa_file)
     if ".gz" in msa_file:
         logging.debug("MSA is gzipped")

--- a/make_prg/io_utils.py
+++ b/make_prg/io_utils.py
@@ -2,7 +2,6 @@ import logging
 import re
 import gzip
 from pathlib import Path
-from typing import Generator, Sequence
 
 from Bio import AlignIO
 
@@ -17,20 +16,9 @@ def load_alignment_file(msa_file: str, alignment_format: str):
         handle.close()
     else:
         alignment = AlignIO.read(msa_file, alignment_format)
+    for record in alignment:
+        record.seq = record.seq.upper()
     return alignment
-
-
-def remove_duplicates(seqs: Sequence) -> Generator:
-    seen = set()
-    for x in seqs:
-        if x in seen:
-            continue
-        seen.add(x)
-        yield x
-
-
-def remove_gaps(sequence: str) -> str:
-    return sequence.replace("-", "")
 
 
 # ************/

--- a/make_prg/make_prg_from_msa.py
+++ b/make_prg/make_prg_from_msa.py
@@ -616,7 +616,6 @@ class AlignedSeq(object):
         logging.debug("found the max of %s is %d", max_nesting, m)
         return m
 
-
     @property
     def prop_in_match_intervals(self):
         length_match_intervals = 0

--- a/make_prg/seq_utils.py
+++ b/make_prg/seq_utils.py
@@ -4,6 +4,7 @@ import itertools
 
 from Bio import AlignIO
 
+
 def remove_duplicates(seqs: Sequence) -> Generator:
     seen = set()
     for x in seqs:
@@ -15,6 +16,7 @@ def remove_duplicates(seqs: Sequence) -> Generator:
 
 def remove_gaps(sequence: str) -> str:
     return sequence.replace("-", "")
+
 
 iupac = {
     "R": "GA",
@@ -29,6 +31,7 @@ iupac = {
     "T": "T",
 }
 allowed_bases = set(iupac.keys())
+
 
 def get_interval_seqs(interval_alignment: AlignIO.MultipleSeqAlignment):
     """Replace - with nothing, remove seqs containing N or other non-allowed letters

--- a/make_prg/seq_utils.py
+++ b/make_prg/seq_utils.py
@@ -31,7 +31,8 @@ iupac = {
     "T": "T",
 }
 allowed_bases = set(iupac.keys())
-ambiguous_bases = allowed_bases.difference({"A", "C", "G", "T"})
+standard_bases = {"A", "C", "G", "T"}
+ambiguous_bases = allowed_bases.difference(standard_bases)
 
 
 def get_interval_seqs(interval_alignment: AlignIO.MultipleSeqAlignment):

--- a/make_prg/seq_utils.py
+++ b/make_prg/seq_utils.py
@@ -1,0 +1,58 @@
+import logging
+from typing import Generator, Sequence
+import itertools
+
+from Bio import AlignIO
+
+def remove_duplicates(seqs: Sequence) -> Generator:
+    seen = set()
+    for x in seqs:
+        if x in seen:
+            continue
+        seen.add(x)
+        yield x
+
+
+def remove_gaps(sequence: str) -> str:
+    return sequence.replace("-", "")
+
+iupac = {
+    "R": "GA",
+    "Y": "TC",
+    "K": "GT",
+    "M": "AC",
+    "S": "GC",
+    "W": "AT",
+    "A": "A",
+    "C": "C",
+    "G": "G",
+    "T": "T",
+}
+allowed_bases = set(iupac.keys())
+
+def get_interval_seqs(interval_alignment: AlignIO.MultipleSeqAlignment):
+    """Replace - with nothing, remove seqs containing N or other non-allowed letters
+    and duplicate sequences containing RYKMSW, replacing with AGCT alternatives """
+    gapless_seqs = [str(record.seq.ungap("-")) for record in interval_alignment]
+
+    callback_seqs = []
+    expanded_set = set()
+    for seq in remove_duplicates(gapless_seqs):
+        if len(expanded_set) == 0:
+            callback_seqs.append(seq)
+        if not set(seq).issubset(allowed_bases):
+            continue
+        alternatives = [iupac[base] for base in seq]
+        for expanded_seq in itertools.product(*alternatives):
+            expanded_set.add("".join(expanded_seq))
+
+    if len(expanded_set) == 0:
+        logging.warning(
+            "WARNING: Every sequence must have contained an N in this slice - redo sequence curation because this is nonsense"
+        )
+        logging.warning(f'Sequences were: {" ".join(callback_seqs)}')
+        logging.warning(
+            "Using these sequences anyway, and should be ignored downstream"
+        )
+        return sorted(callback_seqs)
+    return sorted(list(expanded_set))

--- a/make_prg/seq_utils.py
+++ b/make_prg/seq_utils.py
@@ -31,6 +31,7 @@ iupac = {
     "T": "T",
 }
 allowed_bases = set(iupac.keys())
+ambiguous_bases = allowed_bases.difference({"A", "C", "G", "T"})
 
 
 def get_interval_seqs(interval_alignment: AlignIO.MultipleSeqAlignment):

--- a/make_prg/subcommands/prg_from_msa.py
+++ b/make_prg/subcommands/prg_from_msa.py
@@ -2,7 +2,7 @@ import logging
 import os
 from pathlib import Path
 
-from make_prg import make_prg_from_msa, utils
+from make_prg import make_prg_from_msa, io_utils
 
 
 def run(options):
@@ -59,12 +59,12 @@ def run(options):
             min_match_length=options.min_match_length,
         )
         logging.info("Write PRG file to %s.prg", prefix)
-        utils.write_prg(prefix, aseq.prg)
+        io_utils.write_prg(prefix, aseq.prg)
         m = aseq.max_nesting_level_reached
         logging.info("Max_nesting_reached\t%d", m)
 
     logging.info("Write GFA file to %s.gfa", prefix)
-    utils.write_gfa("%s.gfa" % prefix, aseq.prg)
+    io_utils.write_gfa("%s.gfa" % prefix, aseq.prg)
 
     summary_file = Path(prefix).parent / "summary.tsv"
     with summary_file.open("a") as s:

--- a/make_prg/utils.py
+++ b/make_prg/utils.py
@@ -1,9 +1,23 @@
 import logging
 import re
+import gzip
 from pathlib import Path
 from typing import Generator, Sequence
 
+from Bio import AlignIO
+
 from make_prg.prg_encoder import PrgEncoder
+
+def load_alignment_file(msa_file: str, alignment_format: str):
+    logging.info("Read from MSA file %s", msa_file)
+    if ".gz" in msa_file:
+        logging.debug("MSA is gzipped")
+        handle = gzip.open(msa_file, "rt")
+        alignment = AlignIO.read(handle, alignment_format)
+        handle.close()
+    else:
+        alignment = AlignIO.read(msa_file, alignment_format)
+    return alignment
 
 
 def remove_duplicates(seqs: Sequence) -> Generator:

--- a/tests/test_make_prg_from_msa.py
+++ b/tests/test_make_prg_from_msa.py
@@ -1,61 +1,101 @@
 import os
-import unittest
+from unittest import TestCase, mock
 
-from make_prg import make_prg_from_msa
+from make_prg.make_prg_from_msa import AlignedSeq
 
 this_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 data_dir = os.path.join(this_dir, "tests", "data", "make_prg_from_msa")
 
 
-class TestMakePrgFromMsa(unittest.TestCase):
+@mock.patch.object(AlignedSeq, "check_nonmatch_intervals")
+@mock.patch.object(AlignedSeq, "get_prg")
+@mock.patch.object(AlignedSeq, "get_consensus")
+class TestIntervalPartitioning(TestCase):
+    def test_all_non_match(self, get_consensus, _, __):
+        get_consensus.return_value = "******"
+        tester = AlignedSeq("_", alignment="_", min_match_length=3)
+        match, non_match = tester.interval_partition()
+        self.assertEqual(match, [])
+        self.assertEqual(non_match, [[0, 5]])
+
+    def test_all_match(self, get_consensus, _, __):
+        get_consensus.return_value = "ATATAAA"
+        tester = AlignedSeq("_", alignment="_", min_match_length=3)
+        match, non_match = tester.interval_partition()
+        self.assertEqual(match, [[0, 6]])
+        self.assertEqual(non_match, [])
+
+    def test_short_match_counted_as_non_match(self, get_consensus, _, __):
+        get_consensus.return_value = "AT***"
+        tester = AlignedSeq("_", alignment="_", min_match_length=3)
+        match, non_match = tester.interval_partition()
+        self.assertEqual(match, [])
+        self.assertEqual(non_match, [[0, 4]])
+
+    def test_match_non_match_match(self, get_consensus, _, __):
+        get_consensus.return_value = "ATT**AAAC"
+        tester = AlignedSeq("_", alignment="_", min_match_length=3)
+        match, non_match = tester.interval_partition()
+        self.assertEqual(match, [[0, 2], [5, 8]])
+        self.assertEqual(non_match, [[3, 4]])
+
+    def test_end_in_non_match(self, get_consensus, _, __):
+        get_consensus.return_value = "**ATT**AAA*C"
+        tester = AlignedSeq("_", alignment="_", min_match_length=3)
+        match, non_match = tester.interval_partition()
+        self.assertEqual(match, [[2, 4], [7, 9]])
+        self.assertEqual(non_match, [[0, 1], [5, 6], [10, 11]])
+
+
+class TestMakePrgFromMsaFile_IntegrationTests(TestCase):
     def test_answers(self):
         infile = os.path.join(data_dir, "match.fa")
-        aseq = make_prg_from_msa.AlignedSeq(infile)
+        aseq = AlignedSeq(infile)
         self.assertEqual(aseq.prg, "ACGTGTTTTGTAACTGTGCCACACTCTCGAGACTGCATATGTGTC")
 
         infile = os.path.join(data_dir, "nonmatch.fa")
-        aseq = make_prg_from_msa.AlignedSeq(infile)
+        aseq = AlignedSeq(infile)
         self.assertEqual(aseq.prg, " 5 AAACGTGGTT 6 CCCCCCCCCC 5 ")
 
         infile = os.path.join(data_dir, "match.nonmatch.fa")
-        aseq = make_prg_from_msa.AlignedSeq(infile)
+        aseq = AlignedSeq(infile)
         self.assertEqual(aseq.prg, "AAACG 5 TGGTT 6 CCCCC 5 ")
 
         infile = os.path.join(data_dir, "nonmatch.match.fa")
-        aseq = make_prg_from_msa.AlignedSeq(infile)
+        aseq = AlignedSeq(infile)
         self.assertEqual(aseq.prg, " 5 AAACGT 6 CCCCCC 5 GGTT")
 
         infile = os.path.join(data_dir, "match.nonmatch.match.fa")
-        aseq = make_prg_from_msa.AlignedSeq(infile)
+        aseq = AlignedSeq(infile)
         self.assertEqual(aseq.prg, "AAACG 5 C 6 T 5 GGTT")
 
         infile = os.path.join(data_dir, "shortmatch.nonmatch.match.fa")
-        aseq = make_prg_from_msa.AlignedSeq(infile)
+        aseq = AlignedSeq(infile)
         self.assertEqual(aseq.prg, " 5 AAACGT 6 ATTTTC 5 GGTT")
 
         infile = os.path.join(data_dir, "match.nonmatch.shortmatch.fa")
-        aseq = make_prg_from_msa.AlignedSeq(infile)
+        aseq = AlignedSeq(infile)
         self.assertEqual(aseq.prg, "AAAC 5 GTGGTT 6 CCCCCT 5 ")
 
         infile = os.path.join(data_dir, "match.staggereddash.fa")
-        aseq = make_prg_from_msa.AlignedSeq(infile)
+        aseq = AlignedSeq(infile)
         self.assertEqual(aseq.prg, "AAACGTGGTT")
 
         infile = os.path.join(data_dir, "contains_n.fa")
-        aseq = make_prg_from_msa.AlignedSeq(infile)
+        aseq = AlignedSeq(infile)
         self.assertEqual(aseq.prg, "AAACG 5 C 6 T 5 GGTT")
 
         infile = os.path.join(data_dir, "contains_RYKMSW.fa")
-        aseq = make_prg_from_msa.AlignedSeq(infile)
+        aseq = AlignedSeq(infile)
         self.assertEqual(aseq.prg, "AAACG 5 C 6 T 5 GGTT")
 
         infile = os.path.join(data_dir, "contains_n_and_RYKMSW.fa")
-        aseq = make_prg_from_msa.AlignedSeq(infile)
+        aseq = AlignedSeq(infile)
         self.assertEqual(aseq.prg, "AAACG 5 C 6 T 5 GGTT")
 
         infile = os.path.join(data_dir, "contains_n_and_RYKMSW_no_variants.fa")
-        aseq = make_prg_from_msa.AlignedSeq(infile)
+        aseq = AlignedSeq(infile)
         self.assertEqual(aseq.prg, "AAACGTGGTT")
 
         # with pytest.raises(Exception):
-        #    aseq = make_prg_from_msa.AlignedSeq("test/fails.fa")
+        #    aseq = AlignedSeq("test/fails.fa")

--- a/tests/test_make_prg_from_msa.py
+++ b/tests/test_make_prg_from_msa.py
@@ -67,7 +67,7 @@ class TestMakePrgFromMsaFile_IntegrationTests(TestCase):
 
         infile = os.path.join(data_dir, "match.nonmatch.match.fa")
         aseq = AlignedSeq(infile)
-        self.assertEqual(aseq.prg, "AAACG 5 C 6 T 5 GGTT")
+        self.assertEqual(aseq.prg, "AAACG 5 T 6 C 5 GGTT")
 
         infile = os.path.join(data_dir, "shortmatch.nonmatch.match.fa")
         aseq = AlignedSeq(infile)
@@ -83,15 +83,15 @@ class TestMakePrgFromMsaFile_IntegrationTests(TestCase):
 
         infile = os.path.join(data_dir, "contains_n.fa")
         aseq = AlignedSeq(infile)
-        self.assertEqual(aseq.prg, "AAACG 5 C 6 T 5 GGTT")
+        self.assertEqual(aseq.prg, "AAACG 5 T 6 C 5 GGTT")
 
         infile = os.path.join(data_dir, "contains_RYKMSW.fa")
         aseq = AlignedSeq(infile)
-        self.assertEqual(aseq.prg, "AAACG 5 C 6 T 5 GGTT")
+        self.assertEqual(aseq.prg, "AAACG 5 T 6 C 5 GGTT")
 
         infile = os.path.join(data_dir, "contains_n_and_RYKMSW.fa")
         aseq = AlignedSeq(infile)
-        self.assertEqual(aseq.prg, "AAACG 5 C 6 T 5 GGTT")
+        self.assertEqual(aseq.prg, "AAACG 5 T 6 C 5 GGTT")
 
         infile = os.path.join(data_dir, "contains_n_and_RYKMSW_no_variants.fa")
         aseq = AlignedSeq(infile)

--- a/tests/test_prg_encoder.py
+++ b/tests/test_prg_encoder.py
@@ -18,14 +18,12 @@ class TestPrgEncoder(unittest.TestCase):
 
         self.assertTrue("Char '' is not in" in str(context.exception))
 
-    @given(text(alphabet=characters(blacklist_characters="ACGTacgt"), max_size=1000))
+    @given(characters(blacklist_characters="ACGTacgt", max_codepoint=10000))
     def test_dnaToInt_char_not_valid_raises_assert_error(self, char):
         encoder = PrgEncoder()
 
         with self.assertRaises(ConversionError) as context:
             encoder._dna_to_int(char)
-
-        self.assertTrue("Char '{}' is not in".format(char) in str(context.exception))
 
     def test_dnaToInt_char_valid_returns_int(self):
         encoder = PrgEncoder()

--- a/tests/test_prg_encoder.py
+++ b/tests/test_prg_encoder.py
@@ -18,7 +18,7 @@ class TestPrgEncoder(unittest.TestCase):
 
         self.assertTrue("Char '' is not in" in str(context.exception))
 
-    @given(text(alphabet=characters(blacklist_characters="ACGTacgt")))
+    @given(text(alphabet=characters(blacklist_characters="ACGTacgt"), max_size=1000))
     def test_dnaToInt_char_not_valid_raises_assert_error(self, char):
         encoder = PrgEncoder()
 

--- a/tests/test_seq_utils.py
+++ b/tests/test_seq_utils.py
@@ -22,6 +22,14 @@ class TestGetIntervals(unittest.TestCase):
         expected = {"GAAAT", "AAAAT", "GGAAT", "AGAAT"}
         self.assertEqual(set(result), expected)
 
+    def test_first_sequence_in_is_first_sequence_out(self):
+        alignment = AlignIO.MultipleSeqAlignment(
+            [SeqRecord(Seq("TTTT")), SeqRecord(Seq("AAAA")), SeqRecord(Seq("CC-C")),]
+        )
+        result = get_interval_seqs(alignment)
+        expected = ["TTTT", "AAAA", "CCC"]
+        self.assertEqual(expected, result)
+
 
 class TestRemoveGaps(unittest.TestCase):
     def test_empty_string_returns_empty(self):

--- a/tests/test_seq_utils.py
+++ b/tests/test_seq_utils.py
@@ -8,20 +8,20 @@ from Bio.SeqRecord import SeqRecord
 
 from make_prg.seq_utils import remove_gaps, get_interval_seqs
 
+
 class TestGetIntervals(unittest.TestCase):
     def test_ambiguous_bases_one_seq(self):
-        alignment = AlignIO.MultipleSeqAlignment([SeqRecord(Seq("RWAAT"))]
-        )
+        alignment = AlignIO.MultipleSeqAlignment([SeqRecord(Seq("RWAAT"))])
         result = get_interval_seqs(alignment)
         expected = {"GAAAT", "AAAAT", "GTAAT", "ATAAT"}
         self.assertEqual(set(result), expected)
 
     def test_ambiguous_bases_one_seq_with_repeated_base(self):
-        alignment = AlignIO.MultipleSeqAlignment([SeqRecord(Seq("RRAAT"))]
-                                                 )
+        alignment = AlignIO.MultipleSeqAlignment([SeqRecord(Seq("RRAAT"))])
         result = get_interval_seqs(alignment)
         expected = {"GAAAT", "AAAAT", "GGAAT", "AGAAT"}
         self.assertEqual(set(result), expected)
+
 
 class TestRemoveGaps(unittest.TestCase):
     def test_empty_string_returns_empty(self):
@@ -61,5 +61,3 @@ class TestRemoveGaps(unittest.TestCase):
         actual = remove_gaps(seq)
 
         self.assertFalse("-" in actual)
-
-

--- a/tests/test_seq_utils.py
+++ b/tests/test_seq_utils.py
@@ -2,9 +2,26 @@ import unittest
 
 from hypothesis import given
 from hypothesis.strategies import text
+from Bio import AlignIO
+from Bio.Seq import Seq
+from Bio.SeqRecord import SeqRecord
 
-from make_prg.utils import *
+from make_prg.seq_utils import remove_gaps, get_interval_seqs
 
+class TestGetIntervals(unittest.TestCase):
+    def test_ambiguous_bases_one_seq(self):
+        alignment = AlignIO.MultipleSeqAlignment([SeqRecord(Seq("RWAAT"))]
+        )
+        result = get_interval_seqs(alignment)
+        expected = {"GAAAT", "AAAAT", "GTAAT", "ATAAT"}
+        self.assertEqual(set(result), expected)
+
+    def test_ambiguous_bases_one_seq_with_repeated_base(self):
+        alignment = AlignIO.MultipleSeqAlignment([SeqRecord(Seq("RRAAT"))]
+                                                 )
+        result = get_interval_seqs(alignment)
+        expected = {"GAAAT", "AAAAT", "GGAAT", "AGAAT"}
+        self.assertEqual(set(result), expected)
 
 class TestRemoveGaps(unittest.TestCase):
     def test_empty_string_returns_empty(self):


### PR DESCRIPTION
TLDR: shorter and more readable code, and unit tests on the individual functions

My initial main goal was to enforce the following: **the first sequence given in the input MSA should be the first path through the output PRG**

This is currently a strong assumption `gramtools` makes, for genotyping.
I don't know if this codebase was initially designed this way. I did find it was not enforced on master branch. I fixed it and added quite a few tests that give me more confidence it is now enforced. It might be more tests are needed to check it holds for nested prgs later.

In the process, I refactored the code. I made an explicit effort to i) Reduce if/else induced code nesting and ii) Make the code shorter, by for eg removing assertions (with tests) and terser code constructs. I find the code easier to delve into now.

I also added more general unit tests which complement the existing integration tests by testing the individual functions used by `make_prg_from_msa` module.

Also fixes bug #12